### PR TITLE
US-1723: Allow inline_entity_form as 1.x and 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "drupal/core": "^9.5 || ^10",
     "drupal/dropzonejs": "^2.8",
     "drupal/entity_browser": "^2.8",
-    "drupal/inline_entity_form": "^2.0",
+    "drupal/inline_entity_form": "^1.0 || ^2.0",
     "drupal/svg_formatter": "^2.0",
     "npm-asset/exif-js": "^2.3",
     "npm-asset/dropzone": "^5.9"


### PR DESCRIPTION
This PR allows both inline_entity_form 1.x and 2.x to maximize compatibility. 
See https://www.drupal.org/project/inline_entity_form/issues/2576445#comment-15278849 about interoperability.