### PR TITLE
Adjust dependency as per recommendation on project page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "drupal/core": "^9.5 || ^10",
     "drupal/dropzonejs": "^2.8",
     "drupal/entity_browser": "^2.8",
-    "drupal/inline_entity_form": "^1.0 || ^2.0",
+    "drupal/inline_entity_form": "^1.0 || ^3.0",
     "drupal/svg_formatter": "^2.0",
     "npm-asset/exif-js": "^2.3",
     "npm-asset/dropzone": "^5.9"


### PR DESCRIPTION
This PR adjusts the drupal/inline_entity_form dependency to ^1.0 || ^3.0 as per recommendation: https://www.drupal.org/project/inline_entity_form/issues/3407711